### PR TITLE
Strip the slashes at the beginning of the path for more compability

### DIFF
--- a/Feed/FeedController.php
+++ b/Feed/FeedController.php
@@ -48,7 +48,7 @@ class FeedController extends Controller
     public function __construct(Request $request)
     {
         $config = collect($this->getConfig('feeds', []))->first(function ($key, $feed) use ($request) {
-            return $feed['route'] == $request->getPathInfo();
+            return ltrim($feed['route'], '/') == ltrim($request->getPathInfo(), '/');
         });
 
         $this->title = array_get($config, 'title');


### PR DESCRIPTION
Hi,

Thanks for this module! I had a problem where i entered `rss.xml` in the Route field, which didn't gave a result. After digging in the code i noticed it expected `/rss.xml` to work. This change strippes the beginning `/` from the Route and the request uri so that you can enter both `rss.xml` and `/rss.xml` and they both work.